### PR TITLE
build dev on empty directory and updating readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
-# WIP - NYC Benefits Screening API
+# NYC Benefits Screening API
 
 This repository contains the documentation for the NYC Benefits Screening API managed by [NYC Opportunity](nyc.gov/opportuntiy).
+
+## Getting Started
+Make sure to install the modules in the documentation by running:
+```
+npm i
+```
+### Running
+To load the documentation, run
+```
+npm run start
+```
+
+### Updating
+To make updates to the documentation, run
+```
+npm run dev
+```
+All updates will be saved within `dev/`
+
+### Building
+To build the documentation for distribution, run
+```
+npm run build
+```
+
+### Publishing
+To publish the update to the documentation Github page, run
+```
+npm run publish
+```
+The project will build and then deploy to Github Pages
+
+## Updating Content
+Some of the content has been pulled out of this branch to be maintained by the team. You can make edits to the content on the documentation pages by editing the markdown files in the [content](https://github.com/CityOfNewYork/screeningapi-docs/tree/content) branch.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,16 +30,6 @@ const SOURCE = 'src/';
 const PACKAGE = require('./package.json');
 
 // SCRIPTS
-gulp.task('scripts', function() {
-  return gulp.src([
-    DIST + 'js/source.js',
-  ])
-    .pipe(concat('source.js'))
-    .pipe(gulp.dest(DIST + 'js'))
-    .pipe(gulpif((NODE_ENV !== 'development'),
-      notify({message: 'Scripts task complete'})));
-});
-
 gulp.task('scripts:browserify', function() {
   return browserify({
     entries: [SOURCE + 'js/main.js'],
@@ -55,6 +45,15 @@ gulp.task('scripts:browserify', function() {
       notify({message: 'Scripts:browserify task complete'})));
 });
 
+gulp.task('scripts', gulp.series('scripts:browserify', function() {
+  return gulp.src([
+    DIST + 'js/source.js',
+  ])
+    .pipe(concat('source.js'))
+    .pipe(gulp.dest(DIST + 'js'))
+    .pipe(gulpif((NODE_ENV !== 'development'),
+      notify({message: 'Scripts task complete'})));
+}));
 
 // STYLES - LINTING
 gulp.task('lint-css', function() {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Documentation for the NYC Benefits Screening API https://screeningapidocs.cityofnewyork.us/",
   "author": "The Mayor's Office for Economic Opportunity",
   "license": "GPL-3.0",
-  "main": "npm run dev",
+  "main": "npm run start",
   "homepage": "https://github.com/CityOfNewYork/screeningapi-docs",
   "repository": {
     "type": "git",
@@ -16,7 +16,7 @@
     "serve": "node app/serve.js",
     "publish": "npm run build && node app/publish.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "gulp": "gulp",
+    "start": "gulp",
     "dev": "cross-env NODE_ENV=development gulp",
     "purge": "curl -X POST https://purge.jsdelivr.net/gh/CityOfNewYork/screeningapi-docs@content"
   },


### PR DESCRIPTION
Looks like when you ran `npm run dev` a lot of the files wouldn't compile into the `dev/` directory and if `dev/` was empty, it would throw an error. Initially had `allowEmpty: true` for the `scripts` task, but this wouldn't compile the icons, so I just updated the series so that it would.

Also, the readme is updated because it's not a WIP anymore.