### PR TITLE
Don't display bulk upload errors is title case

### DIFF
--- a/dist/bulk-submission-form.html
+++ b/dist/bulk-submission-form.html
@@ -204,7 +204,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/change-password-form.html
+++ b/dist/change-password-form.html
@@ -202,7 +202,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/eligibility-guidelines.html
+++ b/dist/eligibility-guidelines.html
@@ -150,7 +150,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/endpoints.html
+++ b/dist/endpoints.html
@@ -165,7 +165,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/feedback-and-support.html
+++ b/dist/feedback-and-support.html
@@ -150,7 +150,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/getting-started.html
+++ b/dist/getting-started.html
@@ -150,7 +150,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/index.html
+++ b/dist/index.html
@@ -208,7 +208,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/js/source.js
+++ b/dist/js/source.js
@@ -17440,7 +17440,7 @@ var displayErrors = function displayErrors(responseText, showPath) {
       var elementPath = error.elementPath,
           message = error.message;
       var errorMsg = elementPath && showPath ? message + ' Element Path: ' + elementPath + '.' : message;
-      return '<li>' + toTitleCase(errorMsg) + '</li>';
+      return '<li>' + errorMsg + '</li>';
     });
   } catch (err) {}
 

--- a/dist/making-a-request.html
+++ b/dist/making-a-request.html
@@ -168,7 +168,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/overview.html
+++ b/dist/overview.html
@@ -150,7 +150,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/request-builder.html
+++ b/dist/request-builder.html
@@ -409,7 +409,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/sample-data-and-code.html
+++ b/dist/sample-data-and-code.html
@@ -150,7 +150,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/terms-of-service.html
+++ b/dist/terms-of-service.html
@@ -150,7 +150,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/dist/token-based-authentication.html
+++ b/dist/token-based-authentication.html
@@ -150,7 +150,7 @@
 
     <div id="markdown-about-nyc-opportunity"></div>
 
-    <small>© City of New York, 2019 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
+    <small>© City of New York, 2020 All Rights Reserved.<br>NYC is a trademark and service mark of the City of New York.</small>
   </div>
 </footer>
   <script crossorigin='anonymous' src='https://polyfill.io/v3/polyfill.min.js?flags=gated&features=Array.prototype.forEach,Element.prototype.matches,Element.prototype.remove,fetch,Promise'></script>

--- a/src/js/modules/util.js
+++ b/src/js/modules/util.js
@@ -61,7 +61,7 @@ export const displayErrors = (responseText, showPath) => {
       const { elementPath, message } = error
       const errorMsg = elementPath && showPath ?
         message + ' Element Path: ' + elementPath + '.' : message
-      return '<li>' + toTitleCase(errorMsg) + '</li>'
+      return '<li>' + errorMsg + '</li>'
     })
   } catch (err) {}
   setTextBox(errorsArray.join(''), 'block', errorBoxId);


### PR DESCRIPTION
Changes made:

- don't call toTitleCase on bulk upload error messages. If a column is missing from the request, we display an error "ColumnName missing". Some columns have names that start with a lower case character, which are incorrectly changed to upper case by the existing logic.